### PR TITLE
fix(ARN-247): hide all <content:encoded> from public arena rss

### DIFF
--- a/components/features/RSS/xml.js
+++ b/components/features/RSS/xml.js
@@ -144,9 +144,9 @@ const rssTemplate = (
               videoSelect,
             )) &&
             body && {
-              'content:encoded': {
-                $: body,
-              },
+              // 'content:encoded': {
+              //   $: body,
+              // },
             }),
           ...(includePromo && img && { '#': img }),
           ...(sectionName && { category: sectionName }),


### PR DESCRIPTION
fix(ARN-247): hide all <content:encoded> from public arena rss. make sure the public don't have access to the body content, they only get it from from url so that they can be redirected to our website.